### PR TITLE
Decoupled the policy JSON structure from the tool logic, and generate policy matrix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,14 @@ Engineered for **safety**, **idempotency**, and **scalability**, featuring paral
 
 ## 🏗️ Architecture
 
-This toolset consists of three core components:
+This toolset separates policy definitions from execution logic:
 
 | Component | Description |
 |:---|:---|
-| [`common.sh`](file:///Users/vivekmankonda/Documents/GitHub/my-rulesets/common.sh) | **Shared Infrastructure**: API helpers, logging, error handling, and parallel state management. |
-| [`setup_github_rules.sh`](file:///Users/vivekmankonda/Documents/GitHub/my-rulesets/setup_github_rules.sh) | **Sync Engine**: The primary tool for creating and updating the "Protect Master" ruleset. |
-| [`delete_github_rules.sh`](file:///Users/vivekmankonda/Documents/GitHub/my-rulesets/delete_github_rules.sh) | **Cleanup Engine**: Safely deletes rulesets by name or wipes all rulesets from a target. |
+| **`common.sh`** | **Shared Infrastructure**: API helpers, logging, error handling, and parallel state management. |
+| **`setup_github_rules.sh`** | **Sync Engine**: Creates and updates rulesets dynamically loaded from JSON policy configurations. |
+| **`delete_github_rules.sh`** | **Cleanup Engine**: Safely deletes rulesets using `--config` (extracts name automatically) or raw `--name`. |
+| **`policies/`** | **Policy Matrix**: 9 JSON configuration files categorized by scale (`individual`, `team`, `org`) and strictness. |
 
 ---
 
@@ -57,28 +58,25 @@ This toolset consists of three core components:
 
 ### 1. Setting Up & Updating Rulesets
 ```bash
-# Test on a single repository (Dry Run)
-./setup_github_rules.sh --repo my-fi --dry-run
+# Test a policy on a single repository (Dry Run)
+./setup_github_rules.sh --config policies/team/moderate.json --repo my-fi --dry-run
 
-# Apply to specific repositories with debug output
-./setup_github_rules.sh --repos "my-fi, borderless-buy" --debug-diff
+# Apply structural policies to specific repositories
+./setup_github_rules.sh --config policies/individual/strict.json --repos "my-fi, borderless-buy"
 
-# Scale out: Apply to ALL public repositories, processing 5 at a time
-./setup_github_rules.sh --all --visibility public --parallel 5
+# Scale out: Apply org-level rules to ALL public repositories, processing 5 at a time
+./setup_github_rules.sh --config policies/org/strict.json --all --visibility public --parallel 5
 
-# Security Audit: Apply but FAIL if any currently have Bypass Actors configured
-./setup_github_rules.sh --all --enforce-no-bypass
-
-# Security Remediation: Force wipe Bypass Actors across all private repos
-./setup_github_rules.sh --all --visibility private --remove-bypass
+# Security Audit: Compare live state against strict policy without making changes
+./setup_github_rules.sh --config policies/org/strict.json --all --dry-run
 ```
 
 ### 2. Deleting Rulesets
 ```bash
-# Safely verify what would happen if you delete a specific ruleset
-./delete_github_rules.sh --all --name "Protect Master" --dry-run
+# Extract the target ruleset name from the JSON config and safely simulate deleting it
+./delete_github_rules.sh --config policies/team/moderate.json --all --dry-run
 
-# Delete a specifically named ruleset from multiple selected repositories
+# Delete a ruleset via literal string name instead of config file
 ./delete_github_rules.sh --repos "my-fi, old-project" --name "Protect Master" --yes
 
 # Nuke Option: Delete ALL rulesets on a specific repository
@@ -91,6 +89,7 @@ This toolset consists of three core components:
 
 | Flag | Description | Default |
 |:---|:---|:---|
+| `--config <path>` | **[Required by setup]** Path to JSON policy file | - |
 | `--all` | Apply to all matching repos | `true` |
 | `--repo <name>` | Apply to a single repository | - |
 | `--repos <a,b>` | Apply to comma-separated repositories | - |

--- a/delete_github_rules.sh
+++ b/delete_github_rules.sh
@@ -23,6 +23,7 @@ Scope:
   --include-archived          Include archived repos
 
 Target:
+  --config <path>             Path to JSON policy file (extracts name to delete)
   --name <name>               Delete only rulesets matching this name (default: all rulesets)
 
 Behavior:
@@ -38,6 +39,16 @@ for raw_arg in "$@"; do normalize_unicode_dashes "$raw_arg"; done
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --config)
+      [[ $# -ge 2 ]] || { error "--config requires a value"; exit 1; }
+      if [[ ! -f "$2" ]]; then error "Config file not found: $2"; exit 1; fi
+      TARGET_RULESET="$(cat "$2" | jq -r .name 2>/dev/null || echo '')"
+      if [[ -z "$TARGET_RULESET" || "$TARGET_RULESET" == "null" ]]; then
+        error "Failed to extract 'name' from $2"
+        exit 1
+      fi
+      shift 2
+      ;;
     --all) MODE="all"; shift ;;
     --repo)
       [[ $# -ge 2 ]] || { error "--repo requires a value"; exit 1; }

--- a/policies/individual/loose.json
+++ b/policies/individual/loose.json
@@ -1,0 +1,15 @@
+{
+  "name": "Individual - Loose",
+  "target": "branch",
+  "enforcement": "evaluate",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" }
+  ]
+}

--- a/policies/individual/moderate.json
+++ b/policies/individual/moderate.json
@@ -1,0 +1,15 @@
+{
+  "name": "Individual - Moderate",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" }
+  ]
+}

--- a/policies/individual/strict.json
+++ b/policies/individual/strict.json
@@ -1,0 +1,16 @@
+{
+  "name": "Individual - Strict",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_signatures" }
+  ]
+}

--- a/policies/org/loose.json
+++ b/policies/org/loose.json
@@ -1,0 +1,26 @@
+{
+  "name": "Org - Loose",
+  "target": "branch",
+  "enforcement": "evaluate",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_signatures" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 1,
+        "required_review_thread_resolution": true
+      }
+    }
+  ]
+}

--- a/policies/org/moderate.json
+++ b/policies/org/moderate.json
@@ -1,0 +1,26 @@
+{
+  "name": "Org - Moderate",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_signatures" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 2,
+        "required_review_thread_resolution": true
+      }
+    }
+  ]
+}

--- a/policies/org/strict.json
+++ b/policies/org/strict.json
@@ -1,0 +1,27 @@
+{
+  "name": "Org - Strict",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_signatures" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 2,
+        "required_review_thread_resolution": true
+      }
+    }
+  ]
+}

--- a/policies/team/loose.json
+++ b/policies/team/loose.json
@@ -1,0 +1,25 @@
+{
+  "name": "Team - Loose",
+  "target": "branch",
+  "enforcement": "evaluate",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 1,
+        "required_review_thread_resolution": true
+      }
+    }
+  ]
+}

--- a/policies/team/moderate.json
+++ b/policies/team/moderate.json
@@ -1,0 +1,25 @@
+{
+  "name": "Team - Moderate",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 1,
+        "required_review_thread_resolution": true
+      }
+    }
+  ]
+}

--- a/policies/team/strict.json
+++ b/policies/team/strict.json
@@ -1,0 +1,25 @@
+{
+  "name": "Team - Strict",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 2,
+        "required_review_thread_resolution": true
+      }
+    }
+  ]
+}

--- a/setup_github_rules.sh
+++ b/setup_github_rules.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Script-specific variables
-RULESET_NAME="Protect Master"
+CONFIG_FILE=""
 DEBUG_DIFF=false
 ENFORCE_NO_BYPASS=false
 REMOVE_BYPASS=false
@@ -16,7 +16,10 @@ usage() {
 GitHub repository ruleset manager
 
 Usage:
-  $0 [options]
+  $0 --config <path> [options]
+
+Config:
+  --config <path>             Path to the ruleset JSON policy file (Required)
 
 Scope:
   --all                       Apply to all matching repos (default)
@@ -43,6 +46,11 @@ for raw_arg in "$@"; do normalize_unicode_dashes "$raw_arg"; done
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --config)
+      [[ $# -ge 2 ]] || { error "--config requires a value"; exit 1; }
+      CONFIG_FILE="$2"
+      shift 2
+      ;;
     --all) MODE="all"; shift ;;
     --repo)
       [[ $# -ge 2 ]] || { error "--repo requires a value"; exit 1; }
@@ -105,36 +113,17 @@ require_cmd jq
 check_auth
 setup_state_dir
 
-# Dynamic payload injection (unquoted EOF allows variable expansion)
-read -r -d '' BASE_PAYLOAD <<EOF || true
-{
-  "name": "$RULESET_NAME",
-  "target": "branch",
-  "enforcement": "active",
-  "conditions": {
-    "ref_name": {
-      "include": [
-        "~DEFAULT_BRANCH"
-      ],
-      "exclude": []
-    }
-  },
-  "rules": [
-    { "type": "deletion" },
-    { "type": "non_fast_forward" },
-    {
-      "type": "pull_request",
-      "parameters": {
-        "dismiss_stale_reviews_on_push": true,
-        "require_code_owner_review": false,
-        "require_last_push_approval": false,
-        "required_approving_review_count": 1,
-        "required_review_thread_resolution": true
-      }
-    }
-  ]
-}
-EOF
+if [[ -z "$CONFIG_FILE" || ! -f "$CONFIG_FILE" ]]; then
+  error "You must specify a valid policy JSON file using --config"
+  exit 1
+fi
+
+BASE_PAYLOAD="$(cat "$CONFIG_FILE")"
+RULESET_NAME="$(printf '%s' "$BASE_PAYLOAD" | jq -r .name)"
+if [[ -z "$RULESET_NAME" || "$RULESET_NAME" == "null" ]]; then
+  error "Failed to extract 'name' from $CONFIG_FILE"
+  exit 1
+fi
 
 canonicalize_ruleset() {
   jq -S '


### PR DESCRIPTION
…d the 3x3 policy matrix

1. REFACTOR setup_github_rules.sh:
- Remove hardcoded BASE_PAYLOAD.
- Add --config <path> flag to load external JSON.
- Dynamically extract 'name' from JSON via jq to use as the search key.
- Preserve resilience: with_retry wrapper, check_rate_limit, and atomic record_state.
- Preserve parallel PID failure tracking in the main loop.

2. GENERATE POLICY MATRIX (9 JSON files in policies/): Structure: policies/[individual|team|org]/[loose|moderate|strict].json
- Individual: Focus on personal safety (no-force-push).
- Team: Focus on collaboration (1-2 reviews, thread resolution).
- Org: Focus on compliance (signed commits, restricted bypass, 2+ reviews).
- Rigor levels (Loose/Moderate/Strict) should scale 'enforcement' (evaluate vs active) and review counts.